### PR TITLE
Minor fixes

### DIFF
--- a/uris.js
+++ b/uris.js
@@ -227,7 +227,7 @@
   			q = this.heirpart().authority();
   			T.authority = q ? '//' + q : '';
   		}
-  		T.scheme = this.scheme();
+  		T.scheme = this.scheme() || '';
   	}
   	q = reference.fragment();
   	T.fragment = q ? q : '';

--- a/uris.js
+++ b/uris.js
@@ -122,7 +122,7 @@
   removeDotSegments: function( input ) {
   	var output = '';
   	var q = null;
-  	while( input.length > 0 ) {
+  	while( input.toString().length > 0 ) {
   		if( input.substr(0,3) == '../' || input.substr(0,2) == './' ) {
   			input = input.slice(input.indexOf('/'));
   		} else if( input == '/.' ) {
@@ -272,7 +272,7 @@
   path: function() {
   	var q = this.authority();
   	if( !q ) return new URI.Path(this);
-  	return new URI.Path( this.slice(q.length + 2) );
+  	return new URI.Path( this.slice(q.toString().length + 2) );
   }
 };
 


### PR DESCRIPTION
Hello,

I fixed 2 problems, or they were at least in my environment.

- My javascript engines don't seem to allow overriding String.length, so I added a call to toString().
- Don't return literal `null` string for an empty scheme.

Tests pass again after these minor fixes.

Would you like to check if you are interested in applying them?